### PR TITLE
Pass additional arguments to hotkey action

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ function registerShortcut (configKey, action) {
       globalShortcut.unregister(accelerator);
       const registered = globalShortcut.register(
         accelerator,
-        () => action.apply(this, [app, ...args])
+        () => action(app, ...args)
       );
       if (!registered) {
         dialog.showMessageBox({

--- a/index.js
+++ b/index.js
@@ -2,14 +2,14 @@ const { dialog, globalShortcut } = require('electron');
 const getShortcutFromConfig = require('./modules/getShortcutFromConfig');
 
 function registerShortcut (configKey, action) {
-  return (app) => {
+  return (app, ...args) => {
     const { plugins, config } = app;
     function register (accelerator) {
       if (!accelerator) return;
       globalShortcut.unregister(accelerator);
       const registered = globalShortcut.register(
         accelerator,
-        () => action(app)
+        () => action.apply(this, [app, ...args])
       );
       if (!registered) {
         dialog.showMessageBox({


### PR DESCRIPTION
Allow for passing additional arguments to the action tied to the hotkey.

This is necessary to support the changes in soutar/hyperterm-summon#15.